### PR TITLE
Integrate Open Trivia DB module and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# RPG_Game_v.01
+# RPG Game v.01
+
+Small console RPG demo that uses trivia questions from [Open Trivia DB](https://opentdb.com).
+
+## Requisitos
+- Node.js 18 o superior
+
+## Instalación
+```bash
+npm install
+```
+
+## Ejecutar tests
+```bash
+npm test
+```
+
+## Ejecutar demo de preguntas
+```bash
+npm run demo
+```
+
+Si deseas persistir preguntas en Postgres define las variables `PGHOST`, `PGUSER`, `PGPASSWORD` y `PGDATABASE` antes de ejecutar.

--- a/demo.js
+++ b/demo.js
@@ -1,0 +1,11 @@
+import { initTriviaSession, getQuestion, timedAsk } from './src/trivia.js';
+
+(async () => {
+  await initTriviaSession();
+  for (let i = 0; i < 3; i++) {
+    const q = await getQuestion();
+    const ok = await timedAsk(q, 10);
+    console.log(ok ? '✅ Correcto\n' : '❌ Fallo\n');
+  }
+  process.exit(0);
+})();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.js']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rpg-game",
+  "version": "1.0.0",
+  "description": "Console RPG demo with trivia questions",
+  "type": "module",
+  "scripts": {
+    "test": "jest",
+    "demo": "node demo.js"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/src/trivia.js
+++ b/src/trivia.js
@@ -1,0 +1,62 @@
+import fetch from 'node-fetch';
+import readline from 'readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const API_ROOT = 'https://opentdb.com';
+let TRIVIA_TOKEN = null;
+const asked = new Set();
+
+export async function initTriviaSession() {
+  const r = await fetch(`${API_ROOT}/api_token.php?command=request`);
+  const { token } = await r.json();
+  TRIVIA_TOKEN = token;
+}
+
+export async function getQuestion({ category = null, difficulty = null } = {}) {
+  if (!TRIVIA_TOKEN) await initTriviaSession();
+  let url = `${API_ROOT}/api.php?amount=1&token=${TRIVIA_TOKEN}`;
+  if (category) url += `&category=${category}`;
+  if (difficulty) url += `&difficulty=${difficulty}`;
+  let data = await fetch(url).then(r => r.json());
+  if (data.response_code === 4) {
+    await fetch(`${API_ROOT}/api_token.php?command=reset&token=${TRIVIA_TOKEN}`);
+    data = await fetch(url).then(r => r.json());
+  }
+  const q = data.results[0];
+  const decodedQ = {
+    ...q,
+    question: htmlDecode(q.question),
+    correct_answer: htmlDecode(q.correct_answer),
+    incorrect_answers: q.incorrect_answers.map(htmlDecode)
+  };
+  if (asked.has(decodedQ.question)) return getQuestion({ category, difficulty });
+  asked.add(decodedQ.question);
+  return decodedQ;
+}
+
+export async function timedAsk(qObj, seconds = 15) {
+  const choices = shuffle([qObj.correct_answer, ...qObj.incorrect_answers]);
+  console.log(`\n${qObj.question}`);
+  choices.forEach((c, i) => console.log(`${i + 1}) ${c}`));
+  const rl = readline.createInterface({ input, output });
+  const timer = setTimeout(() => rl.close(), seconds * 1000);
+  try {
+    const answer = await rl.question(`\nTienes ${seconds}s → elige 1-${choices.length}: `);
+    clearTimeout(timer);
+    return choices[Number(answer) - 1] === qObj.correct_answer;
+  } catch {
+    console.log('\n⏰ ¡Tiempo agotado!');
+    return false;
+  }
+}
+
+function shuffle(arr) {
+  return arr.sort(() => Math.random() - 0.5);
+}
+
+function htmlDecode(str) {
+  return str
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(n))
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&');
+}

--- a/src/turn.js
+++ b/src/turn.js
@@ -1,0 +1,24 @@
+import { randomInt } from 'crypto';
+import { getQuestion, timedAsk } from './trivia.js';
+
+export async function lanzarDado(player) {
+  const roll = randomInt(1, 7); // 1..6
+  console.log(`\n🎲 Dado: ${roll}`);
+  const q = await getQuestion();
+  const ok = await timedAsk(q, 15);
+  if (roll <= 3) {
+    if (!ok) {
+      player.hp -= 10;
+      console.log('Respuesta incorrecta. Pierdes 10 HP.');
+    } else {
+      console.log('Nada sucede.');
+    }
+  } else {
+    if (ok) {
+      player.hp += 10;
+      console.log('Respuesta correcta. Ganas 10 HP.');
+    } else {
+      console.log('Nada sucede.');
+    }
+  }
+}

--- a/tests/trivia.test.js
+++ b/tests/trivia.test.js
@@ -1,0 +1,11 @@
+import { initTriviaSession, getQuestion } from '../src/trivia.js';
+
+test('no se repite en 50 llamadas', async () => {
+  await initTriviaSession();
+  const texts = new Set();
+  for (let i = 0; i < 50; i++) {
+    const q = await getQuestion();
+    expect(texts.has(q.question)).toBe(false);
+    texts.add(q.question);
+  }
+});


### PR DESCRIPTION
## Summary
- add npm project setup with jest config
- implement `src/trivia.js` to fetch questions from Open Trivia DB
- implement `lanzarDado` in `src/turn.js`
- add demo script and unit test
- update README with usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605aca11108328b1beb6a0205b8acc